### PR TITLE
Pass along field precision — FE-5228

### DIFF
--- a/dist/mapd-crossfilter.js
+++ b/dist/mapd-crossfilter.js
@@ -16735,6 +16735,7 @@ function replaceRelative(sqlStr) {
                 table: table,
                 column: element.name,
                 type: element.type,
+                precision: element.precision,
                 is_array: element.is_array,
                 is_dict: element.is_dict,
                 name_is_ambiguous: false

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -513,6 +513,7 @@ export function replaceRelative(sqlStr) {
                 table: table,
                 column: element.name,
                 type: element.type,
+                precision: element.precision,
                 is_array: element.is_array,
                 is_dict: element.is_dict,
                 name_is_ambiguous: false

--- a/test/crossfilter.spec.js
+++ b/test/crossfilter.spec.js
@@ -96,8 +96,8 @@ describe("crossfilter", () => {
     })
     it("identifies ambiguous table columns", () => {
       const columnsArray = [
-        { name: "age", type: "idk", is_array: false, is_dict: false },
-        { name: "age", type: "other", is_array: false, is_dict: false }
+        { name: "age", type: "idk", is_array: false, is_dict: false, precision: 0 },
+        { name: "age", type: "other", is_array: false, is_dict: false, precision: 0 }
       ]
       getFieldsReturnValue = columnsArray
       const dataConnector = { getFields }
@@ -109,7 +109,8 @@ describe("crossfilter", () => {
             type: "other",
             is_array: false,
             is_dict: false,
-            name_is_ambiguous: true
+            name_is_ambiguous: true,
+            precision: 0
           }
         })
       })
@@ -191,8 +192,8 @@ describe("crossfilter", () => {
   describe(".getColumns", () => {
     it("keeps track of table columns", function() {
       const columnsArray = [
-        { name: "age", type: "idk", is_array: false, is_dict: false },
-        { name: "sex", type: "idk", is_array: false, is_dict: false }
+        { name: "age", type: "idk", is_array: false, is_dict: false, precision: 0 },
+        { name: "sex", type: "idk", is_array: false, is_dict: false, precision: 0 }
       ]
       getFieldsReturnValue = columnsArray
       const dataConnector = { getFields }
@@ -204,7 +205,8 @@ describe("crossfilter", () => {
             type: "idk",
             is_array: false,
             is_dict: false,
-            name_is_ambiguous: false
+            name_is_ambiguous: false,
+            precision: 0
           },
           "tableA.sex": {
             table: "tableA",
@@ -212,7 +214,8 @@ describe("crossfilter", () => {
             type: "idk",
             is_array: false,
             is_dict: false,
-            name_is_ambiguous: false
+            name_is_ambiguous: false,
+            precision: 0
           }
         })
       })


### PR DESCRIPTION
In `getFieldsAsync()`, include column precision property

This is the precision of the column's data type, as reported by the backend via the Thrift bindings. This property is now included when returning the list of fields for a table, along with the pre-existing type, is_array, etc. properties.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Fixes FE-5228

## :smoking: Smoke Test
- [x] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
